### PR TITLE
Cleanups to align with broader purpose

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2643,6 +2643,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2710,6 +2719,7 @@ dependencies = [
  "muda 0.11.5",
  "serde_json",
  "tokio",
+ "tracing-subscriber",
  "warp",
 ]
 
@@ -2822,6 +2832,15 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "num-traits"
@@ -4483,6 +4502,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
 ]
 
 [[package]]
@@ -4491,9 +4522,16 @@ version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
  "sharded-slab",
+ "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -4651,6 +4689,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version-compare"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ serde_json = "1.0.143"
 muda = "0.11.5"
 tokio = { version = "1.0", features = ["time", "rt-multi-thread", "macros"] }
 warp = "0.3"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [features]
 default = ["desktop"]

--- a/assets/main.css
+++ b/assets/main.css
@@ -25,6 +25,14 @@ h3 {
     color: #aaaaaa;
 }
 
+.smaller {
+    font-size: 16px;
+}
+
+.even-smaller {
+    font-size: 12px;
+}
+
 #links {
     width: 400px;
     text-align: left;

--- a/src/components/editor.rs
+++ b/src/components/editor.rs
@@ -108,7 +108,7 @@ pub fn MonacoEditor(initial_value: String) -> Element {
 
                     spawn(async move {
                         let init_js = format!(r#"
-                            console.log('Initializing Monaco Editor...');
+                            console.log('Initializing Monaco Editor from local server...');
 
                             (function initMonaco() {{
                                 function createEditor() {{
@@ -135,7 +135,7 @@ pub fn MonacoEditor(initial_value: String) -> Element {
                                             lineNumbersMinChars: 0
                                         }});
 
-                                        console.log('Monaco Editor created successfully!');
+                                        console.log('Monaco Editor created successfully from localhost:3030!');
                                         window.monaco_ready = true;
                                         
                                         // Set up change listener
@@ -154,30 +154,38 @@ pub fn MonacoEditor(initial_value: String) -> Element {
                                     }}
                                 }}
 
+                                // Check if Monaco was preloaded in main.rs
+                                if (window.monaco_preloaded && typeof monaco !== 'undefined' && monaco.editor) {{
+                                    console.log('Monaco was preloaded in head, using it directly');
+                                    createEditor();
+                                    return;
+                                }}
+
                                 if (typeof monaco !== 'undefined' && monaco.editor) {{
                                     console.log('Monaco already loaded');
                                     createEditor();
                                     return;
                                 }}
 
-                                // Load Monaco from CDN
-                                console.log('Loading Monaco from CDN...');
-                                const cdnScript = document.createElement('script');
-                                cdnScript.src = 'https://cdn.jsdelivr.net/npm/monaco-editor@0.44.0/min/vs/loader.js';
-                                cdnScript.onload = function() {{
-                                    console.log('Monaco loader loaded');
+                                // Load Monaco from local Warp server
+                                console.log('Loading Monaco from localhost:3030...');
+                                const loaderScript = document.createElement('script');
+                                loaderScript.src = 'http://localhost:3030/min/vs/loader.js';
+                                loaderScript.onload = function() {{
+                                    console.log('Monaco loader loaded from local server');
                                     require.config({{
-                                        paths: {{ 'vs': 'https://cdn.jsdelivr.net/npm/monaco-editor@0.44.0/min/vs' }}
+                                        paths: {{ 'vs': 'http://localhost:3030/min/vs' }}
                                     }});
                                     require(['vs/editor/editor.main'], function() {{
-                                        console.log('Monaco main loaded');
+                                        console.log('Monaco main loaded from local server');
                                         createEditor();
                                     }});
                                 }};
-                                cdnScript.onerror = function() {{
-                                    console.error('Failed to load Monaco from CDN');
+                                loaderScript.onerror = function() {{
+                                    console.error('Failed to load Monaco from localhost:3030');
+                                    console.error('Make sure the Warp server is running and serving from ./assets');
                                 }};
-                                document.head.appendChild(cdnScript);
+                                document.head.appendChild(loaderScript);
                             }})();
                         "#);
 
@@ -273,7 +281,7 @@ pub fn MonacoEditor(initial_value: String) -> Element {
                 } else {
                     div {
                         style: "color: #888; font-style: italic;",
-                        "Monaco Editor loading..."
+                        "Monaco Editor loading from localhost:3030..."
                     }
                 }
             }
@@ -288,6 +296,10 @@ pub fn MonacoEditor(initial_value: String) -> Element {
                 p { 
                     style: "margin: 5px 0 0 0; color: #888;",
                     "🔧 Use 'Print Stored Content' to see what's in the Rust signal"
+                }
+                p { 
+                    style: "margin: 5px 0 0 0; color: #4a9eff;",
+                    "🚀 Loading from local Warp server at localhost:3030"
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use muda::{
     Menu, MenuEvent, MenuItem, Submenu,
 };
 use std::process::exit;
+use tracing_subscriber::EnvFilter;
 
 
 mod content;
@@ -25,21 +26,28 @@ fn App() -> Element {
     
     rsx! {
         document::Link { rel: "icon", href: FAVICON }
-        document::Link { rel: "stylesheet", href: MAIN_CSS }
+        //document::Link { rel: "stylesheet", href: MAIN_CSS }
         h1 { "Monaco Editor in Dioxus" }
-        h2 { "with a custom menu using muda" }
-        h3 { "(check devtools console and terminal when clicking buttons)" }
+        h2 { class: "smaller", "with a custom menu using muda" }
+        h3 { class: "even-smaller", "(check devtools console and terminal when clicking buttons)" }
         crate::content::Hero {}
     }
 }
 
 fn main() {
-    
+
+    // Initialize tracing subscriber FIRST to tame warp/hyper logging noise
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::new("error")
+                .add_directive("hyper=error".parse().unwrap())
+                .add_directive("warp=error".parse().unwrap())
+        )
+        .init();
 
     // Start Monaco asset server
     std::thread::spawn(|| {
     
-    std::env::set_var("RUST_LOG", "warp=warn"); //tame warp logging noise
 
     let rt = tokio::runtime::Runtime::new().unwrap();
     rt.block_on(async {
@@ -57,9 +65,11 @@ fn main() {
     });
 
     // Give server time to start
-    std::thread::sleep(std::time::Duration::from_millis(100));
+    // Keeping as comment for now; was more necessary when still allowing load via Monaco CDN
+    //std::thread::sleep(std::time::Duration::from_millis(100));
 
-    // 1. Define the custom menu using muda structs.
+    // Define the custom menu using muda structs.
+    // This should really be factored out someplace else, but people love menus!
     let new_menu_item = MenuItem::with_id(
         NEW_MENU_ITEM_ID,
         "New",
@@ -75,13 +85,13 @@ fn main() {
     );
     let other_menu_item_1 = MenuItem::with_id(
         OTHER_MENU_ITEM_ID_1,
-        "Scary Option 1",
+        "Exciting Option",
         true,
         Some(Accelerator::new(Some(Modifiers::CONTROL), Code::Digit1)),
     );
     let other_menu_item_2 = MenuItem::with_id(
         OTHER_MENU_ITEM_ID_2,
-        "Scary Option 2",
+        "About",
         true,
         Some(Accelerator::new(Some(Modifiers::CONTROL), Code::Digit2)),
     );


### PR DESCRIPTION
- Removed Monaco CDN in favor of local load as primary target it desktop
- Updated styles of a few headings
- Silenced noisy logging from warp/hyper.